### PR TITLE
ci: fix release gh token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,12 @@ jobs:
   release:
     name: "Release"
     uses: HyperaDev/actions/.github/workflows/go-release.yml@main
+    permissions:
+      contents: write # Create releases
+      packages: write # Write packages
     with:
       docker_enabled: true
     secrets:
       DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}"
       DOCKERHUB_TOKEN: "${{ secrets.DOCKERHUB_TOKEN }}"
-      GITHUB_RELEASE_TOKEN: "${{ secrets.BOT_GITHUB_TOKEN }}"
+      GITHUB_RELEASE_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
**Summary**
Use GitHub-created `GITHUB_TOKEN` secret for creating releases.

**Changes**
<!-- A list of changes this pull request makes  -->

**Checklist**
 - [x] I acknowledge and agree to the terms of [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
 - [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
 - [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
 - [ ] I have added appropriate tests and documentation for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->